### PR TITLE
Change internet check to www.gstatic.com/generate_204 and fix syntax error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,14 +65,10 @@ INSTALL_DIR="/usr/share/doc/aircrackauto"
 BIN_DIR="/usr/bin/"
 if [ $choice == 1 ] || [ $choice == 2 ]; then
 	echo "[*] Checking Your Internet Connection .."
-	wget -q --tries=10 --timeout=20 --spider https://google.com
+	wget -q --tries=10 --timeout=20 --spider http://www.gstatic.com/generate_204
 	if [[ $? == 0 ]]; then
         echo -e ${BLUE}"[✔] Loading ... "
-        if [ $choice == 1 ]; then
-            #sudo apt-get update -y && apt-get upgrade -y
-            #sudo apt-get install python3-pip -y
         
-        fi
 
 	    echo "[✔] Checking directories..."
 	    if [ -d "$INSTALL_DIR" ]; then


### PR DESCRIPTION
When i run the install.sh script , a syntax error happened "./install.sh: line 74: syntax error near unexpected token `fi'" , it is because "if .... fi " contains an empty clause , and then change internet check url to www.gstatic.com/generate_204 because google is not available in all regions of the world .